### PR TITLE
chore(deps): Revert jossef/action-latest-release-info action to v1.2.1

### DIFF
--- a/.github/workflows/trigger-release.yaml
+++ b/.github/workflows/trigger-release.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Gets latest created release info
         id: latest_release_info
-        uses: jossef/action-latest-release-info@91c9567e8d5ad9efe800f12fa268a9b67cbe6843 # v1.2.2
+        uses: jossef/action-latest-release-info@v1.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Reverts SpotOnInc/pre-commit-yq#4


1.2.2 works incorrectly, tested before in https://github.com/SpotOnInc/renovate-config/pull/53
Issue: https://github.com/jossef/action-latest-release-info/issues/7