### PR TITLE
fix: Do not write Docker pull logs in fixed file if no yq and yq imag…

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>SpotOnInc/renovate-config"
-  ]
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["local>SpotOnInc/renovate-config"],
 }

--- a/hooks/yq_yaml_prettier.sh
+++ b/hooks/yq_yaml_prettier.sh
@@ -50,6 +50,10 @@ function check_is_deps_installed {
       exit 1
     fi
 
+    # Prevent "Docker pull logs" added to fixed file.
+    # https://github.com/SpotOnInc/pre-commit-yq/issues/9
+    docker pull mikefarah/yq:4 > /dev/null
+
     function yq {
       docker run --rm -i -v "${PWD}":/workdir mikefarah/yq:4 "$@"
     }


### PR DESCRIPTION
…e locally

<!--
Thank you for helping to improve pre-commit-yq!
-->

Put an `x` into the box if that applies:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Fixes #9 


### How was it tested

0. Remove `yq` and docker images `mikefarah/yq`
1. Clone this repo
2. In `.pre-commit-config.yaml` comment

	```yaml
    #  exclude: |
    #    (?x)
    #     # Try to sort consecutive steps
    #     (^.github/workflows
    #   )
    ```
3. Run `pre-commit -a`