### PR TITLE
fix: Hook failed to work with achors in arrays

### DIFF
--- a/hooks/yq_yaml_prettier.sh
+++ b/hooks/yq_yaml_prettier.sh
@@ -115,7 +115,7 @@ function per_file_hook_unique_part {
   elif
     [ -z "${SORT_REGEXPS["${filename}"]}" ]
   then
-    yq_output=$(yq e '( ... |select(type == "!!seq")) |= sort_by( select(tag == "!!str") //  (keys | .[0]) )' "$filename" 2>&1)
+    yq_output=$(yq e '(.. | select(tag == "!!seq")) |= sort_by(select(tag == "!!str") // .)' "$filename" 2>&1)
     exit_code=$?
     error_type="on whole file"
   else


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-yq!
-->

Put an `x` into the box if that applies:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

in `v0.1.2` next construction will fail:

```yaml
user: &user arn:aws:iam:::user/user
additional_principals:
  - *user
```

with error:
```
Hook failed on whole file. Check the file and hook settings to fix the error.
File: 'user.yaml'
Error: Cannot get keys of , keys only works for maps and arrays
```

Also, this PR fixes similar errors like `Cannot get keys of !!int, keys only works for maps and arrays`
